### PR TITLE
fix typo

### DIFF
--- a/programming-guide/from-here.md
+++ b/programming-guide/from-here.md
@@ -9,7 +9,7 @@
 
 最後，完整的API 文件可以從以下網址連結[scala](https://spark.apache.org/docs/latest/api/scala/#org.apache.spark.package), [java](https://spark.apache.org/docs/latest/api/java/), [python](https://spark.apache.org/docs/latest/api/python/) 中查詢。
 =======
-# 從這禮開始
+# 從這裡開始
 
 你可以從Spark 官方網站找到[ Spark 範例](http://spark.apache.org/examples.html)。另外，Spark 的example 目錄中包含幾個Spark 例子，你可以利用下列方式執行Java或者scala 例子：
 ```shell


### PR DESCRIPTION
Fix typo in  spark-programming-guide-zh-tw/programming-guide/from-here.md
